### PR TITLE
fix: enforce admin authorization in addAdmin server action

### DIFF
--- a/src/app/api/admin/admin_actions.tsx
+++ b/src/app/api/admin/admin_actions.tsx
@@ -3,12 +3,10 @@ import { revalidatePath } from "next/cache";
 import prisma from "@/src/lib/db";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { requireAdmin } from "@/src/lib/auth/requireAdmin";
 
 export async function addAdmin(email: string) {
-  const session = await auth();
-  if (!session) {
-    redirect("/login");
-  }
+  await requireAdmin();
 
   const admin = await prisma.admin.findUnique({
     where: { email },

--- a/src/lib/auth/requireAdmin.ts
+++ b/src/lib/auth/requireAdmin.ts
@@ -1,0 +1,16 @@
+import { auth } from "@/auth";
+import prisma from "@/src/lib/db";
+import { redirect } from "next/navigation";
+
+export async function requireAdmin() {
+  const session = await auth();
+  const email = session?.user?.email;
+  if (!email) {
+    redirect("/login");
+  }
+  const admin = await prisma.admin.findUnique({ where: { email } });
+  if (!admin) {
+    throw new Error("Forbidden");
+  }
+  return session;
+}


### PR DESCRIPTION
## Problem (C1 — privilege escalation)

`addAdmin(email)` in `src/app/api/admin/admin_actions.tsx` only checked `if (!session) redirect("/login")` — i.e. it verified the caller was *authenticated*, never that the caller was an *admin*. Because `"use server"` actions are public POST endpoints, any logged-in (non-admin) user could call `addAdmin` and grant themselves admin (confirmed by replaying the action with a non-admin session). Admin status is defined by a row in the `Admin` collection.

## Fix

- New helper `src/lib/auth/requireAdmin.ts`: loads the session, redirects to `/login` if unauthenticated, looks the email up in the `Admin` table, and throws `Forbidden` if the caller is not an admin.
- `addAdmin` now calls `await requireAdmin()` instead of the bare session check, so only an existing admin can create admins.

No lockout risk: an admin already exists in the `Admin` collection.

## Validation

- `pnpm typecheck` — passes
- `pnpm lint` — passes (only pre-existing `config.ts` warnings)

## Out of scope

C2 (unauthenticated event actions), H1–H3, M1/M2, and the low-severity cleanups are intentionally left for follow-up PRs.