### PR TITLE
fix: derive addEvent data from stored request to prevent calendar-invite abuse

### DIFF
--- a/src/app/api/server_actions/actions.tsx
+++ b/src/app/api/server_actions/actions.tsx
@@ -156,33 +156,37 @@ export async function blockEvent(state: boolean, formData: FormData) {
 export async function addEvent(event: Event) {
   await requireAdmin();
 
-  const id = event.id;
-  const fromDate = event.startDate;
-  const toDate = event.endDate;
-  const name = event.name;
-  const email = event.email;
-  const description = event.description;
+  // Do not trust client-supplied fields. Re-fetch the authoritative
+  // RequestedEvent from the DB and use its stored values to prevent
+  // calendar-invite abuse and arbitrary record injection.
+  const requested = await prisma.requestedEvent.findUnique({
+    where: { id: event.id },
+  });
+
+  if (!requested) {
+    throw new Error("Requested event not found");
+  }
 
   await prisma.event.create({
     data: {
-      id: id,
-      name: name, // Add the name property here
-      description: description,
-      startDate: fromDate,
-      endDate: toDate,
-      email: email,
+      id: requested.id,
+      name: requested.name, // Add the name property here
+      description: requested.description,
+      startDate: requested.startDate,
+      endDate: requested.endDate,
+      email: requested.email,
     },
   });
 
-  const convertToDate = new Date(toDate);
-  const convertFromDate = new Date(fromDate);
+  const convertToDate = new Date(requested.endDate);
+  const convertFromDate = new Date(requested.startDate);
   convertToDate.setDate(convertToDate.getDate() + 1);
-  createCalendarAppointment(
+  await createCalendarAppointment(
     convertFromDate,
     convertToDate,
-    event.email,
-    name,
-    description
+    requested.email,
+    requested.name,
+    requested.description
   );
 }
 


### PR DESCRIPTION
## Bug (H2)

`addEvent` accepted a fully client-supplied `event` object and trusted its fields directly: it wrote them straight to the DB and passed `event.email` / `event.name` / `event.description` to `createCalendarAppointment`. Even though the action is admin-only, a tampered client payload could make the server send REAL Google Calendar invites (from the owner's account) to arbitrary recipients with arbitrary content, and inject arbitrary `Event` records into the DB.

## Fix

In `addEvent`, after `requireAdmin()`, re-fetch the authoritative `RequestedEvent` by id from the DB and use ITS stored values instead of the client-supplied fields:

- `prisma.requestedEvent.findUnique({ where: { id: event.id } })`; throw if not found.
- Create the confirmed `Event` from the stored `requested.*` values (id, name, description, startDate, endDate, email).
- Compute calendar dates from `requested.startDate` / `requested.endDate` (keeping the existing "+1 day on the end date" behavior) and call `createCalendarAppointment` with `requested.email` / `requested.name` / `requested.description`.
- The `createCalendarAppointment` call is now `await`ed so failures surface.

Only `addEvent` changes; the `Event` type and all other functions are untouched.

## Validation

- `pnpm typecheck`: passed (0 errors).
- `pnpm lint`: 0 errors (5 pre-existing `config.ts` semicolon warnings only).

## Out of scope

- M3 (general input validation / rate limiting) is a follow-up.
- The intentionally-open sign-in (no allowlist) is left as-is by design.