### PR TITLE
fix: require admin and prevent admin enumeration in admin actions

### DIFF
--- a/src/app/api/admin/admin_actions.tsx
+++ b/src/app/api/admin/admin_actions.tsx
@@ -2,8 +2,7 @@
 import { revalidatePath } from "next/cache";
 import prisma from "@/src/lib/db";
 import { auth } from "@/auth";
-import { redirect } from "next/navigation";
-import { requireAdmin } from "@/src/lib/auth/requireAdmin";
+import { requireAdmin, isAdmin } from "@/src/lib/auth/requireAdmin";
 
 export async function addAdmin(email: string) {
   await requireAdmin();
@@ -24,36 +23,23 @@ export async function addAdmin(email: string) {
 }
 
 export async function getAdmins() {
-  const session = await auth();
-  if (!session) {
-    redirect("/login");
-  }
+  await requireAdmin();
 
   const admins = await prisma.admin.findMany();
   return admins;
 }
 
-export async function isUserAdmin(email: string) {
+export async function isUserAdmin() {
   const session = await auth();
-  if (!session) {
-    redirect("/login");
-  }
+  const email = session?.user?.email;
   if (!email) {
     return false;
   }
-
-  const admin = await prisma.admin.findUnique({
-    where: { email },
-  });
-
-  return admin ? true : false;
+  return isAdmin(email);
 }
 
 export async function getCalendarLink() {
-  const session = await auth();
-  if (!session) {
-    redirect("/login");
-  }
+  await requireAdmin();
 
   const calendarLink = await prisma.calendarLink.findUnique({
     where: { id: "calendar_link" },
@@ -63,10 +49,7 @@ export async function getCalendarLink() {
 }
 
 export async function setCalendarLink(link: string) {
-  const session = await auth();
-  if (!session) {
-    redirect("/login");
-  }
+  await requireAdmin();
 
   await prisma.calendarLink.upsert({
     where: { id: "calendar_link" },

--- a/src/app/profile/admin/page.tsx
+++ b/src/app/profile/admin/page.tsx
@@ -1,4 +1,3 @@
-import { auth } from "@/auth";
 import ConfirmedEventForm from "@/src/components/ConfirmedEventForm";
 import AddAdminForm from "@/src/components/profile/admin/AddAdminForm";
 import AdminList from "@/src/components/profile/admin/AdminList";
@@ -15,9 +14,7 @@ export default async function AdminProfile() {
   const requestedEventsArray = JSON.parse(JSON.stringify(requestedEvents));
   const events = await prisma.event.findMany();
   const eventsArray = JSON.parse(JSON.stringify(events));
-  const session = await auth();
-  const user = session?.user;
-  const isAdmin = await isUserAdmin(user?.email ?? "");
+  const isAdmin = await isUserAdmin();
   const calendarLink = await getCalendarLink();
 
   if (!isAdmin) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
   useEffect(() => {
     const checkAdminStatus = async () => {
       if (session?.user?.email) {
-        const adminStatus = await isUserAdmin(session.user.email);
+        const adminStatus = await isUserAdmin();
         setIsAdmin(adminStatus);
       }
     };

--- a/src/components/modal/ModalForm.tsx
+++ b/src/components/modal/ModalForm.tsx
@@ -76,7 +76,7 @@ export default function ModalForm({ date, closeModal }: ModalFormProps) {
   useEffect(() => {
     const checkAdminStatus = async () => {
       if (session?.user?.email) {
-        const adminStatus = await isUserAdmin(session.user.email);
+        const adminStatus = await isUserAdmin();
         setIsAdmin(adminStatus);
       }
     };


### PR DESCRIPTION
Fixes two security findings in src/app/api/admin/admin_actions.tsx.

## M1 — admin-only calendar link
- setCalendarLink and getCalendarLink previously required only a session (authentication), letting any logged-in user overwrite the calendar link shown on the admin dashboard. Both now call requireAdmin(), since they are only used on the admin page.

## M2 — admin enumeration / info disclosure
- getAdmins now requires admin (requireAdmin()) instead of any authenticated caller.
- isUserAdmin no longer accepts a caller-supplied email. It derives the email from the session and reuses isAdmin, so a caller can only learn their own admin status. This removes the ability to probe whether any arbitrary address is an admin.

## Call-site updates
The isUserAdmin signature changed (email parameter removed), so all callers were updated:
- src/components/Header.tsx
- src/app/profile/admin/page.tsx (also dropped the now-unused user/auth references)
- src/components/modal/ModalForm.tsx

addAdmin was already using requireAdmin() and is unchanged.

## Validation
- pnpm typecheck: passed
- pnpm lint: 0 errors (only 5 pre-existing config.ts semicolon warnings)