### PR TITLE
security: validate event input, add security headers, and remove client-exposed admin email

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = { 
-    images: {
+const nextConfig = {
+  images: {
     remotePatterns: [
       {
         protocol: 'https',
@@ -28,8 +28,26 @@ const nextConfig = {
       }
     ],
   },
-env:{
-  NEXT_PUBLIC_ADMIN_EMAIL: 'ooueidat@gmail.com'
-}};
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/src/app/api/server_actions/actions.tsx
+++ b/src/app/api/server_actions/actions.tsx
@@ -33,16 +33,32 @@ export async function requestEvent(
 
   const from = formData.get("event-date-from");
   const to = formData.get("event-date-to");
-  const name = formData.get("name");
-  const description = formData.get("description");
+  const name = String(formData.get("name") ?? "").trim();
+  const description = String(formData.get("description") ?? "").trim();
   const isBlockEvent = formData.get("isBlockEvent") === "true";
 
   if (!from || !to) {
     throw new Error("Missing form data");
   }
 
-  if (!isBlockEvent && (!name || !description)) {
-    throw new Error("Missing required fields for booking");
+  if (!isBlockEvent) {
+    if (!name || !description) {
+      throw new Error("Missing required fields for booking");
+    }
+    if (name.length > 100) {
+      return {
+        closeModal: false,
+        message: "",
+        error: "Name cannot be longer than 100 characters",
+      };
+    }
+    if (description.length > 1000) {
+      return {
+        closeModal: false,
+        message: "",
+        error: "Description cannot be longer than 1000 characters",
+      };
+    }
   }
 
   const currentDate = new Date();
@@ -108,8 +124,8 @@ export async function requestEvent(
   await prisma.requestedEvent.create({
     data: {
       id: new ObjectId().toString(),
-      name: name as string, // Add the name property here
-      description: description as string,
+      name: name, // Add the name property here
+      description: description,
       email: session.user?.email as string,
       startDate: fromDate,
       endDate: toDate,
@@ -275,7 +291,10 @@ export async function createCalendarAppointment(
       date: toDate.toISOString().split("T")[0],
       timeZone: "Europe/Stockholm",
     },
-    attendees: [{ email: "ooueidat@gmail.com" }, { email: email }],
+    attendees: [
+      { email: process.env.OWNER_EMAIL ?? "ooueidat@gmail.com" },
+      { email: email },
+    ],
     reminders: {
       useDefault: false,
       overrides: [

--- a/src/components/profile/RequestedEventList.tsx
+++ b/src/components/profile/RequestedEventList.tsx
@@ -32,7 +32,6 @@ export default async function RequestedEventList({
 
   const requestedEventsArray = JSON.parse(JSON.stringify(requestedEvents));
   const eventsArray = JSON.parse(JSON.stringify(events));
-  console.log(eventsArray);
   return (
     <div className="grid grid-cols-1 gap-6">
       {requestedEventsArray.map((event: Record<string, string>) => (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,5 +8,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/calendar", "/profile"],
+  matcher: ["/calendar", "/profile/:path*"],
 };


### PR DESCRIPTION
Batch of security hardening fixes.

## Fixes

- **M3 — Event input validation** (`src/app/api/server_actions/actions.tsx`, `requestEvent`): coerce `name`/`description` to trimmed strings; for non-block events keep the required check and additionally reject `name` > 100 chars and `description` > 1000 chars, returning the existing `{ closeModal, message, error }` error shape. Trimmed values are used when creating the `requestedEvent`. Date checks unchanged.

- **L1 — Client-exposed admin identity**: removed the `env: { NEXT_PUBLIC_ADMIN_EMAIL }` block from `next.config.mjs` (`NEXT_PUBLIC_*` is inlined into the client bundle). `NEXT_PUBLIC_ADMIN_EMAIL` had no code references, so removing the config was sufficient. The hardcoded organizer/attendee literal in `createCalendarAppointment` is now `process.env.OWNER_EMAIL ?? "ooueidat@gmail.com"`. `OWNER_EMAIL` can be set in `.env`; behavior is unchanged if unset.

- **L2 — PII in logs**: removed the `console.log(eventsArray)` line in `src/components/profile/RequestedEventList.tsx` that logged booking records (names/emails).

- **L3 — Security headers**: added an async `headers()` in `next.config.mjs` applying `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`, and `Permissions-Policy: camera=(), microphone=(), geolocation=()` to all routes. **CSP is intentionally deferred** — a wrong policy would break Next inline scripts/styles, next-auth, and Google sign-in, and it cannot be validated here; it should be added separately with a preview-deploy smoke test. `images.remotePatterns` is intact.

- **L5 — Middleware matcher**: widened from `["/calendar", "/profile"]` to `["/calendar", "/profile/:path*"]` so sub-paths like `/profile/admin` are covered. Middleware logic otherwise unchanged.

- **L4 — next-auth (no change)**: `next-auth` remains on `5.0.0-beta.31`. There is no stable v5 to move to, so it is intentionally not bumped, but it should be tracked since it is a beta.

## Validation

- `pnpm typecheck`: passes.
- `pnpm lint`: 0 errors, only the 5 pre-existing `config.ts` semicolon warnings.