### PR TITLE
fix: make createCalendarAppointment an internal function, not a public action

### DIFF
--- a/src/app/api/server_actions/actions.tsx
+++ b/src/app/api/server_actions/actions.tsx
@@ -2,7 +2,7 @@
 import { revalidatePath } from "next/cache";
 import { ObjectId } from "bson";
 import prisma from "@/src/lib/db";
-import getAccessToken from "@/src/lib/availability/getAccessToken";
+import { createCalendarAppointment } from "@/src/lib/calendar/createCalendarAppointment";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import {
@@ -270,62 +270,6 @@ export async function getRequestedEventsForMonth(year: number, month: number) {
     }
   });
   return requestedEventsDict;
-}
-
-export async function createCalendarAppointment(
-  fromDate: Date,
-  toDate: Date,
-  email: string,
-  name: string,
-  description: string
-) {
-  const body = {
-    summary: `${name} i Köpenhamn`,
-    location: "Copenhagen, Denmark",
-    description: { description },
-    start: {
-      date: fromDate.toISOString().split("T")[0],
-      timeZone: "Europe/Stockholm",
-    },
-    end: {
-      date: toDate.toISOString().split("T")[0],
-      timeZone: "Europe/Stockholm",
-    },
-    attendees: [
-      { email: process.env.OWNER_EMAIL ?? "ooueidat@gmail.com" },
-      { email: email },
-    ],
-    reminders: {
-      useDefault: false,
-      overrides: [
-        { method: "email", minutes: 24 * 60 },
-        { method: "popup", minutes: 10 },
-      ],
-    },
-  };
-
-  if (!process.env.GOOGLE_CALENDAR_API_URL) {
-    throw new Error("GOOGLE_OAUTH_SECRET not set");
-  }
-  const apiUrl = new URL(process.env.GOOGLE_CALENDAR_API_URL);
-
-  apiUrl.searchParams.set("sendUpdates", "all");
-  apiUrl.searchParams.set("conferenceDataVersion", "1");
-
-  const response = await fetch(apiUrl, {
-    cache: "no-cache",
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${await getAccessToken()}`,
-    },
-    body: JSON.stringify(body),
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  return response;
 }
 
 export type Card = {

--- a/src/lib/calendar/createCalendarAppointment.ts
+++ b/src/lib/calendar/createCalendarAppointment.ts
@@ -1,0 +1,57 @@
+import getAccessToken from "@/src/lib/availability/getAccessToken";
+
+export async function createCalendarAppointment(
+  fromDate: Date,
+  toDate: Date,
+  email: string,
+  name: string,
+  description: string
+) {
+  const body = {
+    summary: `${name} i Köpenhamn`,
+    location: "Copenhagen, Denmark",
+    description: { description },
+    start: {
+      date: fromDate.toISOString().split("T")[0],
+      timeZone: "Europe/Stockholm",
+    },
+    end: {
+      date: toDate.toISOString().split("T")[0],
+      timeZone: "Europe/Stockholm",
+    },
+    attendees: [
+      { email: process.env.OWNER_EMAIL ?? "ooueidat@gmail.com" },
+      { email: email },
+    ],
+    reminders: {
+      useDefault: false,
+      overrides: [
+        { method: "email", minutes: 24 * 60 },
+        { method: "popup", minutes: 10 },
+      ],
+    },
+  };
+
+  if (!process.env.GOOGLE_CALENDAR_API_URL) {
+    throw new Error("GOOGLE_OAUTH_SECRET not set");
+  }
+  const apiUrl = new URL(process.env.GOOGLE_CALENDAR_API_URL);
+
+  apiUrl.searchParams.set("sendUpdates", "all");
+  apiUrl.searchParams.set("conferenceDataVersion", "1");
+
+  const response = await fetch(apiUrl, {
+    cache: "no-cache",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${await getAccessToken()}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Bug

`src/app/api/server_actions/actions.tsx` starts with the `"use server"` directive, which turns every exported async function into a publicly callable Server Action (a POST endpoint). `createCalendarAppointment(fromDate, toDate, email, name, description)` was exported there with no authorization. It sends a real Google Calendar invite from the owner's Google account (via `getAccessToken()`) to a caller-supplied `email` with caller-supplied `name`/`description`.

This meant anyone could call it directly to relay arbitrary calendar-invite spam from the owner's account, bypassing the already-hardened `addEvent` (which re-fetches authoritative values from the DB and requires admin).

## Fix

Relocated `createCalendarAppointment` verbatim into a plain server module `src/lib/calendar/createCalendarAppointment.ts` that has no `"use server"` directive, so it is no longer a Server Action / public endpoint. `actions.tsx` now imports it and `addEvent` calls the imported function. The now-unused `getAccessToken` import was removed from `actions.tsx`.

Behavior is otherwise unchanged: same signature, same request payload, same env handling.