### PR TITLE
security: rate-limit requestEvent and addAdmin via Upstash Redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@prisma/client": "^6.19.3",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "bson": "^6.10.4",
     "date-fns": "^4.4.0",
     "next": "16.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       bson:
         specifier: ^6.10.4
         version: 6.10.4
@@ -877,6 +883,18 @@ packages:
     resolution: {integrity: sha512-hewo/UMGP1a7O6FG/ThcPzSJdm/WwrYDNkdGgWl6M18H6K6MSitklomWpT9MUtT5KGj++QJb06va/14QBC4pvw==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2399,6 +2417,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -3231,6 +3252,19 @@ snapshots:
 
   '@unrs/rspack-resolver-binding-win32-x64-msvc@1.2.2':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
@@ -4979,6 +5013,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 

--- a/src/app/api/admin/admin_actions.tsx
+++ b/src/app/api/admin/admin_actions.tsx
@@ -3,9 +3,13 @@ import { revalidatePath } from "next/cache";
 import prisma from "@/src/lib/db";
 import { auth } from "@/auth";
 import { requireAdmin, isAdmin } from "@/src/lib/auth/requireAdmin";
+import { addAdminLimiter, isRateLimited } from "@/src/lib/rateLimit";
 
 export async function addAdmin(email: string) {
-  await requireAdmin();
+  const session = await requireAdmin();
+  if (await isRateLimited(addAdminLimiter, session?.user?.email ?? "anonymous")) {
+    return { error: "Too many requests. Please try again later." };
+  }
 
   const admin = await prisma.admin.findUnique({
     where: { email },

--- a/src/app/api/server_actions/actions.tsx
+++ b/src/app/api/server_actions/actions.tsx
@@ -32,8 +32,8 @@ export async function requestEvent(
     redirect("/login");
   }
 
-  const rlId = session.user?.email ?? "anonymous";
-  if (await isRateLimited(requestEventLimiter, rlId)) {
+  const rateLimitId = session.user?.email ?? "anonymous";
+  if (await isRateLimited(requestEventLimiter, rateLimitId)) {
     return {
       closeModal: false,
       message: "",

--- a/src/app/api/server_actions/actions.tsx
+++ b/src/app/api/server_actions/actions.tsx
@@ -10,6 +10,7 @@ import {
   requireSession,
   isAdmin,
 } from "@/src/lib/auth/requireAdmin";
+import { isRateLimited, requestEventLimiter } from "@/src/lib/rateLimit";
 
 type Event = {
   id: string;
@@ -29,6 +30,15 @@ export async function requestEvent(
 
   if (!session) {
     redirect("/login");
+  }
+
+  const rlId = session.user?.email ?? "anonymous";
+  if (await isRateLimited(requestEventLimiter, rlId)) {
+    return {
+      closeModal: false,
+      message: "",
+      error: "Too many requests. Please try again later.",
+    };
   }
 
   const from = formData.get("event-date-from");

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,34 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+const redis = Redis.fromEnv(); // reads UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN
+
+export const requestEventLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(5, "1 h"),
+  prefix: "rl:requestEvent",
+});
+
+export const addAdminLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(10, "1 h"),
+  prefix: "rl:addAdmin",
+});
+
+/**
+ * Returns true if the identifier is OVER the limit (should be blocked).
+ * Fails open: if the limiter throws (e.g. Upstash unreachable / env missing),
+ * logs and returns false so legitimate requests are not broken by an outage.
+ */
+export async function isRateLimited(
+  limiter: Ratelimit,
+  identifier: string
+): Promise<boolean> {
+  try {
+    const { success } = await limiter.limit(identifier);
+    return !success;
+  } catch (e) {
+    console.error("Rate limit check failed, allowing request:", e);
+    return false;
+  }
+}


### PR DESCRIPTION
## What this does

Adds per-user sliding-window rate limiting to two server actions, backed by Upstash Redis:

- `requestEvent` (booking requests): 5 requests per hour per user
- `addAdmin` (admin management): 10 requests per hour per user

Each user is identified by their authenticated email (falling back to `"anonymous"`). Limits use Upstash's sliding-window algorithm via `@upstash/ratelimit` + `@upstash/redis`, keyed with distinct prefixes (`rl:requestEvent`, `rl:addAdmin`). When a user is over the limit, the action returns a friendly `{ error: "Too many requests. Please try again later." }` instead of performing the work.

## Fail-open design

The shared `isRateLimited` helper wraps the limiter call in a try/catch. If the limiter throws (Upstash unreachable, env vars missing, etc.), it logs the error and returns `false` (not rate-limited), so a Redis outage or misconfiguration never blocks legitimate requests.

## Setup required

For enforcement to actually take effect, the following env vars must be set:

- `UPSTASH_REDIS_REST_URL`
- `UPSTASH_REDIS_REST_TOKEN`

These must be configured **both** locally (`.env`) **and** in the Vercel project settings for **Production and Preview** environments. Until they are set, the limiter fails open and no rate limiting is applied (requests are allowed as before).

## Dependencies

`package.json` and `pnpm-lock.yaml` add two new runtime dependencies:

- `@upstash/ratelimit`
- `@upstash/redis`
