### PR TITLE
chore: remove unused utils.ts with NEXT_PUBLIC admin email reference

### DIFF
--- a/src/lib/util/utils.ts
+++ b/src/lib/util/utils.ts
@@ -1,3 +1,0 @@
-"use server";
-
-export const ADMIN_EMAIL = process.env.NEXT_PUBLIC_AUTH_ADMIN_EMAIL;


### PR DESCRIPTION
## What

Deletes `src/lib/util/utils.ts`, which contained only:
```ts
"use server";
export const ADMIN_EMAIL = process.env.NEXT_PUBLIC_AUTH_ADMIN_EMAIL;
```

## Why

Found during a post-remediation security scan (LOW-1):
- **Dead code** — grep confirms zero importers anywhere in the codebase.
- It re-introduces the pattern removed in the earlier L1 fix: a `NEXT_PUBLIC_` admin-email reference, which would inline into the client bundle if that env var were ever set.
- It's also an invalid `"use server"` export (those files may only export async functions).

No behavior change (the export was unused). `card_info.tsx` in the same folder is untouched.

## Validation

`pnpm typecheck` ✅, `pnpm lint` ✅, unit + wiring tests ✅ (CI gates these). The real-Upstash integration test self-skips in CI.