### PR TITLE
Cache admin status in session to gate UI

### DIFF
--- a/.claude/skills/code-commit/SKILL.md
+++ b/.claude/skills/code-commit/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: code-commit
+description: Generate and validate conventional commit messages following the conventionalcommits.org spec. Use whenever the user wants to commit code, mentions commit messages, git commit, or asks to create a commit. Triggers on "commit", "git commit", "conventional", or when reviewing commit message format.
+user-invocable: true
+---
+
+# Conventional Commit Skill
+
+Generate and validate commit messages following the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+## Conventional Commit Format
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type       | Description                               |
+| ---------- | ----------------------------------------- |
+| `feat`     | New feature                               |
+| `fix`      | Bug fix                                   |
+| `docs`     | Documentation only                        |
+| `style`    | Code style (formatting, semicolons, etc.) |
+| `refactor` | Code change that neither fixes nor adds   |
+| `test`     | Adding or updating tests                  |
+| `chore`    | Build, tooling, dependencies              |
+| `perf`     | Performance improvement                   |
+| `ci`       | CI configuration changes                  |
+| `build`    | Build system or dependencies              |
+| `revert`   | Reverting a previous commit               |
+
+### Rules
+
+- **Subject**: Short description, imperative mood, lowercase, no period at end
+- **Scope**: Optional, lowercase, describes what was changed (e.g., `auth`, `api`, `ui`)
+- **Breaking changes**: Add `!` after type/scope: `feat(auth)!: change API`
+- **Footer**: For breaking changes (`BREAKING CHANGE:`) or issue references (`Closes #123`)
+
+## Operations
+
+### 1. Generate Commit from Diff
+
+When user wants to commit changes:
+
+1. Run `git status` to see changed files
+2. Run `git diff --staged` for staged changes
+3. Analyze what changed to determine:
+   - **Type**: Which type best describes the changes?
+   - **Scope**: What area was affected? (optional)
+   - **Subject**: What was done? (imperative: "add" not "added")
+4. Create a conventional commit message
+5. Run `git commit -m "<message>"`
+
+**Example:**
+
+```
+feat(auth): add JWT token refresh
+
+Implements token refresh endpoint to extend sessions
+without requiring re-authentication.
+
+Closes #142
+```
+
+### 2. Validate Commit Message
+
+When user asks to validate or check a commit message:
+
+1. Parse the commit message
+2. Check format: `<type>(<scope>): <subject>`
+3. Validate type is from the allowed list
+4. Check subject follows rules (lowercase, imperative, no period)
+5. Flag any issues found
+
+### 3. Create Pull Request
+
+When user wants to open a PR or after finishing commits on a feature branch:
+
+1. Verify on a feature branch (not main): `git branch --show-current`
+2. Check for project PR template: `ls .github/PULL_REQUEST_TEMPLATE.md`
+3. Push branch if needed: `git push -u origin <branch>`
+4. Create PR via `gh pr create`:
+   - Use `--fill` if commits are clean (auto-populates title/body)
+   - Use `--draft` for work-in-progress
+   - Use interactive mode if body needs custom content
+5. Show the PR URL to the user
+
+See [references/pr-workflow.md](references/pr-workflow.md) for full workflow details.
+
+## Input Methods
+
+| Input                              | Action                              |
+| ---------------------------------- | ----------------------------------- |
+| User says "commit" or "git commit" | Generate from git diff, then commit |
+| User says "validate commit"        | Check the commit message format     |
+| User pastes commit message         | Validate the provided message       |
+
+## Auto-Commit Workflow
+
+When generating a commit:
+
+1. Show the user the commit message first
+2. Ask for confirmation before committing (unless user explicitly says "just do it")
+3. Execute `git commit -m "<message>"` after confirmation
+4. Show the result of the commit
+
+## Error Handling
+
+- If no staged changes: `git status` shows nothing → warn user nothing to commit
+- If git not initialized: Initialize repo or warn user
+- If commit fails: Show error and offer to retry
+
+## Examples
+
+**Input:** "I fixed the login bug"
+**Output:**
+
+```
+fix(auth): resolve login timeout issue
+
+Users were logged out after 5 minutes due to
+incorrect token expiry calculation.
+```
+
+**Input:** "I added a new API endpoint for users"
+**Output:**
+
+```
+feat(api): add user profile endpoint
+
+GET /users/:id returns user profile data including
+name, email, and avatar URL.
+
+Closes #89
+```
+
+**Input:** "I changed the auth API, this breaks old clients"
+**Output:**
+
+```
+feat(auth)!: change token validation endpoint
+
+The /auth/verify endpoint now requires Bearer token
+instead of query parameter.
+
+BREAKING CHANGE: Clients must update to send
+Authorization header with Bearer token.
+```

--- a/.claude/skills/code-commit/references/pr-workflow.md
+++ b/.claude/skills/code-commit/references/pr-workflow.md
@@ -1,0 +1,150 @@
+# Pull Request Workflow
+
+Creating GitHub pull requests via the `gh` CLI.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated: `gh auth status`
+- Remote `origin` points to GitHub: `git remote -v`
+- On a feature branch (not main): `git branch --show-current`
+
+## Check for Project Template
+
+Before creating a PR, check if the project has its own PR template:
+
+```bash
+# Check for PR template in .github/
+ls .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || echo "No project template found"
+```
+
+**If found:** Use it. The `gh pr create` command will automatically pick it up.
+
+**If not found:** Use the minimal template below.
+
+---
+
+## Create Pull Request
+
+### Option 1: Auto-fill from commits (recommended)
+
+```bash
+gh pr create --fill
+```
+
+This uses the commit messages as the PR title and body. Best when commits are clean and conventional.
+
+### Option 2: Interactive
+
+```bash
+gh pr create
+```
+
+Opens an editor with the template. Fill in title and body interactively.
+
+### Option 3: Inline (for simple PRs)
+
+```bash
+gh pr create --title "feat(auth): add JWT authentication" --body "Implements token-based auth with refresh support."
+```
+
+---
+
+## PR Title Format
+
+Follow conventional commit style for PR titles:
+
+```
+<type>(<scope>): <description>
+```
+
+Examples:
+
+- `feat(api): add user profile endpoint`
+- `fix(db): resolve connection pool leak`
+- `docs(readme): update installation instructions`
+
+---
+
+## PR Body Template (fallback if no project template)
+
+```markdown
+## Description
+
+<!-- What does this PR do? -->
+
+## Changes
+
+<!-- What changed? -->
+
+## Testing
+
+<!-- How was this tested? -->
+
+## Checklist
+
+- [ ] Tests pass
+- [ ] Commits follow conventional format
+- [ ] Documentation updated (if needed)
+```
+
+---
+
+## Linking Issues
+
+Add issue references in the PR body:
+
+```markdown
+Closes #123
+Fixes #456
+Relates to #789
+```
+
+This auto-closes linked issues when the PR merges.
+
+---
+
+## Draft PRs
+
+For work-in-progress PRs:
+
+```bash
+gh pr create --draft
+```
+
+Mark as ready later:
+
+```bash
+gh pr ready <pr-number>
+```
+
+---
+
+## Review Requests
+
+Request reviewers after creating the PR:
+
+```bash
+gh pr edit <pr-number> --add-reviewer username
+```
+
+Or add via the GitHub web UI.
+
+---
+
+## Verify PR Created
+
+```bash
+gh pr view --web  # Open in browser
+gh pr status      # Show PR status
+```
+
+---
+
+## Common Mistakes
+
+| Mistake             | Fix                                 |
+| ------------------- | ----------------------------------- |
+| PR from main branch | Switch to feature branch first      |
+| No remote           | `git remote add origin <url>`       |
+| Unpushed commits    | `git push -u origin <branch>`       |
+| PR body is empty    | Use `--fill` or write a description |

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: frontend-design
+description: Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.
+---
+
+# Frontend Design
+
+Approach this as the design lead at a small studio known for giving every client a visual identity that could not be mistaken for anyone else's. This client has already rejected proposals that felt templated, and is paying for a distinctive point of view: make deliberate, opinionated choices about palette, typography, and layout that are specific to this brief, and take one real aesthetic risk you can justify.
+
+## Ground it in the subject
+
+If the brief does not pin down what the product or subject is, pin it yourself before designing: name one concrete subject, its audience, and the page's single job, and state your choice. If there's any information in your memory about the human's preferences, context about what they're building, or designs you've made before – use that as a hint. The subject's own world, its materials, instruments, artifacts, and vernacular, is where distinctive choices come from. Build with the brief's real content and subject matter throughout.
+
+## Design principles
+
+For web designs, the hero is a thesis. Open with the most characteristic thing in the subject's world, in whatever form makes sense for it: a headline, an image, an animation, a live demo, an interactive moment. Be deliberate with your choice: a big number with a small label, supporting stats, and a gradient accent is the template answer, only use if that's truly the best option.
+
+Typography carries the personality of the page. Pair the display and body faces deliberately, not the same families you would reach for on any other project, and set a clear type scale with intentional weights, widths, and spacing. Make the type treatment itself a memorable part of the design, not a neutral delivery vehicle for the content.
+
+Structure is information. Structural devices, numbering, eyebrows, dividers, labels, should encode something true about the content, not decorate it. Many generic designs use numbered markers (01 / 02 / 03), but that's only appropriate if the content actually is a sequence - like a real process or a typed timeline where order carries information the reader needs. Question if choices like numbered markers actually make sense before incorporating them.
+
+Leverage motion deliberately. Think about where and if animation can serve the subject: a page-load sequence, a scroll-triggered reveal, hover micro-interactions, ambient atmosphere. An orchestrated moment usually lands harder than scattered effects; choose what the direction calls for. However, sometimes less is more, and extra animation contributes to the feeling that the design is AI-generated.
+
+Match complexity to the vision. Maximalist directions need elaborate execution; minimal directions need precision in spacing, type, and detail. Elegance is executing the chosen vision well.
+
+Consider written content carefully. Often a design brief may not contain real content, and it's up to you to come up with copy. Copy can make a design feel as templated as the design itself. See the below section on writing for more guidance.
+
+## Process: brainstorm, explore, plan, critique, build, critique again
+
+For calibration: AI-generated design right now clusters around three looks: (1) a warm cream background (near #F4F1EA) with a high-contrast serif display and a terracotta accent; (2) a near-black background with a single bright acid-green or vermilion accent; (3) a broadsheet-style layout with hairline rules, zero border-radius, and dense newspaper-like columns. All three are legitimate for some briefs, but they are defaults rather than choices, and they appear regardless of subject. Where the brief pins down a visual direction, follow it exactly — the brief's own words always win, including when it asks for one of these looks. Where it leaves an axis free, don't spend that freedom on one of these defaults. Just like a human designer who's hired, there's often a careful balance between doing what you're good at and taking each project as a chance to experiment and learn.
+
+Work in two passes. First, brainstorm a short design plan based on the human's design brief: create a compact token system with color, type, layout, and signature. Color: describe the palette as 4–6 named hex values. Type: the typefaces for 2+ roles (a characterful display face that's used with restraint, a complementary body face, and a utility face for captions or data if needed). Layout: a layout concept, using one-sentence prose descriptions and ASCII wireframes to ideate and compare. Signature: the single unique element this page will be remembered by that embodies the brief in an appropriate way.
+
+Then review that plan against the brief before building: if any part of it reads like the generic default you would produce for any similar page (work through a similar prompt to see if you arrive somewhere similar) rather than a choice made for this specific brief — revise that part, say what you changed and why. Only after you've confirmed the relative uniqueness of your design plan should you start to write the code, following the revised plan exactly and deriving every color and type decision from it.
+
+When writing the code, be careful of structuring your CSS selector specificities. It's easy to generate CSS classes that cancel each other out (especially with a type-based selector like .section and a element-based selector like .cta). This can happen often with paddings/margins between sections.
+
+Try to do a lot of this planning and iteration in your thinking, and only show ideas to the user when you have higher confidence it'll delight them.
+
+## Restraint and self-critique
+
+Spend your boldness in one place. Let the signature element be the one memorable thing, keep everything around it quiet and disciplined, and cut any decoration that does not serve the brief. Not taking a risk can be a risk itself! Build to a quality floor without announcing it: responsive down to mobile, visible keyboard focus, reduced motion respected. Critique your own work as you build, taking screenshots if your environment supports it – a picture is worth 1000 tokens. Consider Chanel's advice: before leaving the house, take a look in the mirror and remove one accessory. Human creators have memory and always try to do something new, so if you have a space to quickly jot down notes about what you've tried, it can help you in future passes.
+
+## More on writing in design
+
+Words appear in a design for one reason: to make it easier to understand, and therefore easier to use. They are design material, not decoration. Bring the same intentionality to copy that you would bring to spacing and color. Before writing anything, ask what the design needs to say, and how it can best be said to help the person navigate the experience.
+
+Write from the end user's side of the screen. Name things by what people control and recognize, never by how the system is built. A person manages notifications, not webhook config. Describe what something does in plain terms rather than selling it. Being specific is always better than being clever.
+
+Use active voice as default. A control should say exactly what happens when it's used: "Save changes," not "Submit." An action keeps the same name through the whole flow, so the button that says "Publish" produces a toast that says "Published." The vocabulary of an interface is the signposting for someone navigating the product. Cohesion and consistency are how people learn their way around.
+
+Treat failure and emptiness as moments for direction, not mood. Explain what went wrong and how to fix it, in the interface's voice rather than a person's. Errors don't apologize, and they are never vague about what happened. An empty screen is an invitation to act.
+
+Keep the register conversational and tuned: plain verbs, sentence case, no filler, with tone matched to the brand and the audience. Let each element do exactly one job. A label labels, an example demonstrates, and nothing quietly does double duty.

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,9 @@ yarn-error.log*
 # vercel
 .vercel
 
-# local Claude Code config
-.claude/
+# Claude Code: share skills/config, but keep per-user local files out
+.claude/settings.local.json
+.claude/worktrees/
 
 # typescript
 *.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# AGENTS.md
+
+This file serves the purpose of guiding the AI agents working on this repository.
+
+## Repository Overview
+
+Booking Calendar is a visitor-booking app: guests pick a free day and request a
+visit, and admins confirm or block dates.
+
+It is a **pnpm + Turborepo monorepo**. Workspace packages are published under the
+`@repo/*` scope.
+
+```
+apps/
+  web/        # Next.js 16 app (React 19) — the only app today
+packages/
+  config/     # @repo/config — shared tsconfig / tooling config
+  db/         # @repo/db — Prisma client (MongoDB)
+  ui/         # @repo/ui — shared React components
+```
+
+### Running it
+
+```bash
+pnpm install
+pnpm db:generate    # generate the Prisma client (also runs on postinstall)
+pnpm dev            # turbo dev — starts the web app on http://localhost:3000
+```
+
+Other useful scripts (run from the repo root): `pnpm build`, `pnpm lint`,
+`pnpm typecheck`, `pnpm test`, `pnpm format:write`, and `pnpm format:check`. The
+database layer is **Prisma on MongoDB**; `pnpm db:generate` regenerates the
+client and `pnpm db:push` syncs the schema. A `DATABASE_URL` env var is required.
+
+### Next.js docs
+
+`next` is a dependency of `apps/web`, so the version-pinned docs referenced below
+live at **`apps/web/node_modules/next/dist/docs/`**.
+
+## Skills structure
+
+Skills live in the `.claude/skills/` directory. Each skill is a self-contained
+module named after the skill:
+
+```
+.claude/skills/{skill-name}/
+├── SKILL.md           # Main skill definition (REQUIRED — must not be empty)
+└── references/        # Optional additional context
+    └── topic.md
+```
+
+Current skills: `code-commit`, `frontend-design`.
+
+### Skill File Format
+
+`SKILL.md` must start with YAML frontmatter, followed by the instruction body:
+
+```yaml
+---
+name: skill-name
+description: When to use this skill (AI reads this to auto-load)
+---
+```
+
+Skills are auto-invoked based on a match between their `description` and the
+current context. An empty `SKILL.md` will register the skill by name but it will
+not load or do anything.
+
+## Session/Task start
+
+**When starting a session or a task**, you MUST pull the latest changes from main,
+and branch off the main branch given the feature or changes you are given.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT
+complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all
+differ from your training data. Read the relevant guide in
+`node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -1,6 +1,26 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+import { isAdmin } from "@/src/lib/auth/requireAdmin";
 
 export const { auth, handlers, signIn, signOut } = NextAuth({
   providers: [Google],
+  callbacks: {
+    // Resolve admin status once when the JWT is issued/refreshed and cache it
+    // on the token. This is used only to gate the UI (e.g. showing the "Block
+    // Event" button) so the client doesn't need a DB round-trip on every
+    // render. Mutating server actions still verify admin against the DB via
+    // requireAdmin(), so a stale token can never grant unauthorized access.
+    async jwt({ token }) {
+      if (token.email) {
+        token.isAdmin = await isAdmin(token.email);
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.isAdmin = Boolean(token.isAdmin);
+      }
+      return session;
+    },
+  },
 });

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -2,8 +2,6 @@
 
 import Link from "next/link";
 import { signOut, useSession, SessionProvider } from "next-auth/react";
-import { isUserAdmin } from "@/src/app/api/admin/admin_actions";
-import { useEffect, useState } from "react";
 
 const sharedClasses = {
   navContainer: "mx-auto flex items-center justify-between p-4 lg:px-8",
@@ -17,18 +15,7 @@ const sharedClasses = {
 
 export default function Header() {
   const { status, data: session } = useSession();
-  const [isAdmin, setIsAdmin] = useState(false);
-
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (session?.user?.email) {
-        const adminStatus = await isUserAdmin();
-        setIsAdmin(adminStatus);
-      }
-    };
-
-    checkAdminStatus();
-  }, [session?.user?.email]);
+  const isAdmin = Boolean(session?.user?.isAdmin);
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-cph-navy/85 backdrop-blur-md border-b border-white/10">

--- a/apps/web/src/components/modal/ModalForm.tsx
+++ b/apps/web/src/components/modal/ModalForm.tsx
@@ -6,7 +6,6 @@ import { requestEvent, blockEvent } from "@/src/app/api/server_actions/actions";
 import { DateInput, TextInput } from "@repo/ui";
 import { EventContext } from "@/src/components/calendar/Month";
 import { useSession } from "next-auth/react";
-import { isUserAdmin } from "@/src/app/api/admin/admin_actions";
 
 type RequestEventState = Record<string, string | boolean>;
 
@@ -69,19 +68,8 @@ export default function ModalForm({ date, closeModal }: ModalFormProps) {
   );
   const { refreshing, setRefreshing } = useContext(EventContext);
   const { data: session, status } = useSession();
-  const [isAdmin, setIsAdmin] = useState(false);
+  const isAdmin = Boolean(session?.user?.isAdmin);
   const [isBlockEvent, setIsBlockEvent] = useState(false);
-
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (session?.user?.email) {
-        const adminStatus = await isUserAdmin();
-        setIsAdmin(adminStatus);
-      }
-    };
-
-    checkAdminStatus();
-  }, [session?.user?.email]);
 
   useEffect(() => {
     if (state.closeModal || state2) {

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,0 +1,19 @@
+import type { DefaultSession } from "next-auth";
+
+// Module augmentation requires `interface` for declaration merging; `type`
+// cannot merge into the existing next-auth declarations.
+declare module "next-auth" {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface Session {
+    user: {
+      isAdmin: boolean;
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface JWT {
+    isAdmin?: boolean;
+  }
+}


### PR DESCRIPTION
## What

Resolves admin status once in the NextAuth `jwt`/`session` callbacks and exposes it as `session.user.isAdmin`. The `Header` (Admin link) and the booking `ModalForm` (Block Event button) now read that flag synchronously instead of firing an `isUserAdmin()` server-action → DB round-trip inside a `useEffect` on every render.

## Why

The Block Event button (and the Admin nav link) flickered / appeared late because admin status was fetched client-side after the session loaded, hitting the DB on every modal open. Caching the flag in the signed JWT makes it available immediately — no extra round-trip, no flicker.

## Security

UI gating only. Mutating server actions (`blockEvent`, `addEvent`, `addAdmin`, …) still call `requireAdmin()`, which verifies against the DB at write time. A stale or tampered token cannot grant unauthorized access — the JWT flag never becomes the authorization boundary.

### Caveat
With JWT sessions (current setup, no adapter), the cached `isAdmin` refreshes only when the token is re-issued. A newly added admin sees the Admin link / Block Event button after their next sign-in or token refresh; the server enforces the real permission regardless.

## Notes
- Added `apps/web/types/next-auth.d.ts` to type `session.user.isAdmin` and `token.isAdmin`. Uses `interface` (required for module-augmentation merging) with a targeted eslint-disable.
- `isUserAdmin()` is retained — still used by the `/profile/admin` server component as the authoritative check.
- Typecheck and lint pass.