### PR TITLE
feat(ui): reusable Button component with variants

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -15,15 +15,6 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* Tailwind v4's Preflight no longer sets cursor: pointer on buttons, so
-   restore it for every enabled button and role="button" element. */
-@layer base {
-  button:not(:disabled),
-  [role="button"]:not(:disabled) {
-    cursor: pointer;
-  }
-}
-
 /* Quality floor: a visible, on-brand keyboard focus ring everywhere. */
 :focus-visible {
   outline: 2px solid #e6a23c;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -15,6 +15,15 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Tailwind v4's Preflight no longer sets cursor: pointer on buttons, so
+   restore it for every enabled button and role="button" element. */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 /* Quality floor: a visible, on-brand keyboard focus ring everywhere. */
 :focus-visible {
   outline: 2px solid #e6a23c;

--- a/apps/web/src/components/BookingTrainForm.tsx
+++ b/apps/web/src/components/BookingTrainForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useActionState } from "react";
 import { bookTicket } from "@/src/app/api/server_actions/actions";
+import { Button } from "@repo/ui";
 
 const initialState = false;
 
@@ -27,13 +28,14 @@ export default function BookingTrainForm() {
         <option value="stockholm">Stockholm</option>
         <option value="malmo">Malmö</option>
       </select>
-      <button
+      <Button
         type="submit"
         value="submit"
-        className="justify-self-end bg-cph-ochre text-cph-navy hover:bg-amber-300 transition-colors rounded-lg text-sm w-auto inline-block p-1.5"
+        size="none"
+        className="justify-self-end w-auto p-1.5 text-sm"
       >
         Boka tågbiljett
-      </button>
+      </Button>
     </form>
   );
 }

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -49,7 +49,7 @@ export default function Card({ cardInfo }: CardProps) {
 
   return (
     <div
-      className="flex items-center justify-center group h-80 w-60 perspective-[1000px]"
+      className="flex items-center justify-center group h-80 w-60 perspective-[1000px] cursor-pointer"
       onClick={() => setIsFlipped(!isFlipped)}
       onMouseEnter={() => setIsFlipped(true)}
       onMouseLeave={() => setIsFlipped(false)}

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { Card } from "@/src/app/api/server_actions/actions";
 import { useState } from "react";
+import { Button } from "@repo/ui";
 
 type CardProps = {
   cardInfo: Card;
@@ -96,7 +97,7 @@ export default function Card({ cardInfo }: CardProps) {
 
             <div className="flex flex-col gap-3 mt-6">
               <Link href={cardInfo?.imageUrls} passHref>
-                <button className="w-full rounded-lg bg-cph-ochre py-2 px-4 text-sm font-medium text-cph-navy hover:bg-amber-300 transition-colors duration-200 flex items-center justify-center gap-2">
+                <Button variant="primary" size="sm" className="w-full">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     className="h-4 w-4"
@@ -112,10 +113,14 @@ export default function Card({ cardInfo }: CardProps) {
                     />
                   </svg>
                   Läs mer
-                </button>
+                </Button>
               </Link>
               <Link href="/calendar" passHref>
-                <button className="w-full rounded-lg bg-white/5 py-2 px-4 text-sm font-medium text-cph-paper hover:bg-white/10 transition-colors duration-200 flex items-center justify-center gap-2 border border-cph-sky/25">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full border border-cph-sky/25 bg-white/5"
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     className="h-4 w-4"
@@ -131,7 +136,7 @@ export default function Card({ cardInfo }: CardProps) {
                     />
                   </svg>
                   Gå till bokning
-                </button>
+                </Button>
               </Link>
             </div>
           </div>

--- a/apps/web/src/components/ConfirmedEventForm.tsx
+++ b/apps/web/src/components/ConfirmedEventForm.tsx
@@ -3,6 +3,7 @@ import { deleteConfirmedEvent } from "@/src/app/api/server_actions/actions";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
 import { useState } from "react";
+import { Button } from "@repo/ui";
 
 type ConfirmedEventFormProps = {
   event: Record<string, string>;
@@ -72,9 +73,11 @@ export default function ConfirmedEventForm({
       {isAdmin && (
         <div className="mt-auto pt-4 border-t border-cph-sky/15">
           {!confirmDelete ? (
-            <button
+            <Button
+              variant="destructive"
+              size="sm"
+              className="w-full"
               onClick={() => setConfirmDelete(true)}
-              className="w-full bg-cph-rust text-cph-paper hover:bg-cph-rust/85 rounded-lg py-2 px-4 text-sm font-medium transition-colors duration-200 flex items-center justify-center gap-2"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -91,19 +94,23 @@ export default function ConfirmedEventForm({
                 />
               </svg>
               Remove Event
-            </button>
+            </Button>
           ) : (
             <div className="space-y-4">
               <div className="flex gap-3">
-                <button
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
                   onClick={() => setConfirmDelete(false)}
-                  className="flex-1 border border-cph-sky/30 text-cph-paper hover:bg-white/5 rounded-lg py-2 px-4 text-sm font-medium transition-colors duration-200 flex items-center justify-center gap-2"
                 >
                   Cancel
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="flex-1"
                   onClick={() => handleDeleteEvent(event)}
-                  className="flex-1 bg-cph-rust text-cph-paper hover:bg-cph-rust/85 rounded-lg py-2 px-4 text-sm font-medium transition-colors duration-200 flex items-center justify-center gap-2"
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -120,7 +127,7 @@ export default function ConfirmedEventForm({
                     />
                   </svg>
                   Confirm
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { signOut, useSession, SessionProvider } from "next-auth/react";
+import { Button } from "@repo/ui";
 
 const sharedClasses = {
   navContainer: "mx-auto flex items-center justify-between p-4 lg:px-8",
@@ -65,8 +66,10 @@ export default function Header() {
                     {session?.user?.name}
                   </span>
                 </div>
-                <button
-                  className={`${sharedClasses.button} flex items-center gap-2`}
+                <Button
+                  variant="link"
+                  size="none"
+                  className="text-sm"
                   onClick={() => signOut({ callbackUrl: "/", redirect: true })}
                 >
                   <svg
@@ -84,7 +87,7 @@ export default function Header() {
                     />
                   </svg>
                   Logout
-                </button>
+                </Button>
               </div>
             </div>
           ) : (

--- a/apps/web/src/components/RequestEventForm.tsx
+++ b/apps/web/src/components/RequestEventForm.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/src/app/api/server_actions/actions";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
+import { Button } from "@repo/ui";
 
 type RequestEventFormProps = {
   event: Record<string, string>;
@@ -102,9 +103,11 @@ export default function RequestEventForm({
 
       <div className="mt-auto pt-4 border-t border-cph-sky/15">
         <div className="flex gap-3">
-          <button
+          <Button
+            variant="destructive"
+            size="sm"
+            className="flex-1"
             onClick={() => handleDeleteEvent(event)}
-            className="flex-1 bg-cph-rust text-cph-paper hover:bg-cph-rust/85 rounded-lg py-2 px-4 text-sm font-medium transition-colors duration-200 flex items-center justify-center gap-2"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -121,11 +124,13 @@ export default function RequestEventForm({
               />
             </svg>
             Remove
-          </button>
+          </Button>
           {isAdmin && (
-            <button
+            <Button
+              variant="success"
+              size="sm"
+              className="flex-1"
               onClick={() => handleAddEvent(event)}
-              className="flex-1 bg-cph-teal text-cph-paper hover:bg-cph-teal/85 rounded-lg py-2 px-4 text-sm font-medium transition-colors duration-200 flex items-center justify-center gap-2"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -142,7 +147,7 @@ export default function RequestEventForm({
                 />
               </svg>
               Accept
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/apps/web/src/components/authorization/Login.tsx
+++ b/apps/web/src/components/authorization/Login.tsx
@@ -2,6 +2,7 @@
 
 import { signIn } from "next-auth/react"; // Import the signIn function from NextAuth for authentication.
 import { Suspense, useState } from "react";
+import { Button } from "@repo/ui";
 
 export default function LoginForm() {
   const callbackUrl = "/";
@@ -14,10 +15,12 @@ export default function LoginForm() {
 
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <button
+      <Button
+        variant="ghost"
+        size="none"
         onClick={handleSignIn}
         disabled={isLoading}
-        className="w-full flex items-center justify-center gap-3 px-7 py-3 text-cph-paper font-medium text-sm rounded-lg shadow-md hover:shadow-lg focus:shadow-lg focus:outline-hidden focus:ring-0 active:shadow-lg transition duration-150 ease-in-out bg-white/5 hover:bg-white/10 border border-cph-sky/15 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full gap-3 px-7 py-3 text-sm bg-white/5 border border-cph-sky/15 shadow-md hover:shadow-lg"
       >
         {isLoading ? (
           <div className="w-5 h-5 border-2 border-cph-sky/20 border-t-cph-sky rounded-full animate-spin" />
@@ -42,7 +45,7 @@ export default function LoginForm() {
           </svg>
         )}
         <span>Logga in med Google</span>
-      </button>
+      </Button>
     </Suspense>
   );
 }

--- a/apps/web/src/components/calendar/Calendar.tsx
+++ b/apps/web/src/components/calendar/Calendar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Month from "@/src/components/calendar/Month";
 import { useState, useEffect, Suspense, useCallback } from "react";
+import { Button } from "@repo/ui";
 
 export default function Calendar() {
   const date = new Date();
@@ -38,9 +39,10 @@ export default function Calendar() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={previousMonth}
-            className="p-2 rounded-lg hover:bg-white/10 transition-colors duration-200"
             aria-label="Previous month"
           >
             <svg
@@ -57,19 +59,21 @@ export default function Calendar() {
                 d="M15 19l-7-7 7-7"
               />
             </svg>
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
             onClick={() => {
               setMonth(date.getMonth());
               setYear(date.getFullYear());
             }}
-            className="px-4 py-2 text-sm font-medium text-cph-paper border border-cph-sky/30 hover:bg-white/5 rounded-lg transition-colors duration-200"
           >
             Today
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={nextMonth}
-            className="p-2 rounded-lg hover:bg-white/10 transition-colors duration-200"
             aria-label="Next month"
           >
             <svg
@@ -86,7 +90,7 @@ export default function Calendar() {
                 d="M9 5l7 7-7 7"
               />
             </svg>
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/apps/web/src/components/calendar/NavigateMonthButton.tsx
+++ b/apps/web/src/components/calendar/NavigateMonthButton.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@repo/ui";
+
 type NavigateMonthButtonProps = {
   onClick: () => void;
   children: string;
@@ -8,12 +10,8 @@ export default function NavigateMonthButton({
   children,
 }: NavigateMonthButtonProps) {
   return (
-    <button
-      //className=" bg-zinc-500 hover:bg-zinc-700 border border-zinc-600 text-white-500 font-bold py-2 px-4 rounded"
-      className="border border-cph-sky/30 text-cph-paper p-2 rounded-lg hover:bg-white/5 shadow-md"
-      onClick={onClick}
-    >
+    <Button variant="outline" size="icon" className="shadow-md" onClick={onClick}>
       {children}
-    </button>
+    </Button>
   );
 }

--- a/apps/web/src/components/modal/EventModal.tsx
+++ b/apps/web/src/components/modal/EventModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ModalForm from "./ModalForm";
 import { useEffect } from "react";
+import { Button } from "@repo/ui";
 
 type EventModalProps = {
   closeModal: () => void;
@@ -40,8 +41,10 @@ export default function EventModal({
                 </h1>
                 <p className="text-lg text-cph-sky">{dateString}</p>
               </div>
-              <button
-                className="text-cph-sky/70 hover:text-cph-paper transition-colors duration-200 p-2 rounded-full hover:bg-white/5"
+              <Button
+                variant="ghost"
+                size="icon"
+                className="rounded-full text-cph-sky/70 hover:bg-white/5 hover:text-cph-paper"
                 onClick={closeModal}
                 aria-label="Close modal"
               >
@@ -58,7 +61,7 @@ export default function EventModal({
                     d="M6 18L18 6M6 6l12 12"
                   />
                 </svg>
-              </button>
+              </Button>
             </div>
             <ModalForm date={dateString} closeModal={closeModal} />
           </div>

--- a/apps/web/src/components/modal/ModalForm.tsx
+++ b/apps/web/src/components/modal/ModalForm.tsx
@@ -3,7 +3,7 @@
 import { useFormStatus } from "react-dom";
 import { useActionState, useContext, useEffect, useState } from "react";
 import { requestEvent, blockEvent } from "@/src/app/api/server_actions/actions";
-import { DateInput, TextInput } from "@repo/ui";
+import { Button, DateInput, TextInput } from "@repo/ui";
 import { EventContext } from "@/src/components/calendar/Month";
 import { useSession } from "next-auth/react";
 
@@ -25,10 +25,10 @@ type ModalFormProps = {
 function SubmitButton() {
   const { pending } = useFormStatus();
   return (
-    <button
+    <Button
       type="submit"
       value="submit"
-      className="bg-cph-ochre text-cph-navy hover:bg-amber-300 font-medium py-2 px-6 rounded-lg transition-colors duration-200 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-xs hover:shadow-md"
+      className="px-6 shadow-xs hover:shadow-md"
       disabled={pending}
     >
       {pending ? (
@@ -53,7 +53,7 @@ function SubmitButton() {
           <span>Boka</span>
         </>
       )}
-    </button>
+    </Button>
   );
 }
 
@@ -137,12 +137,13 @@ export default function ModalForm({ date, closeModal }: ModalFormProps) {
 
       <div className="flex justify-end gap-3 pt-4">
         {status === "authenticated" && isAdmin && (
-          <button
+          <Button
             type="submit"
             value="submit"
+            variant="destructive"
             formAction={formAction2}
             onClick={handleBlockEventClick}
-            className="bg-cph-rust hover:bg-cph-rust/80 text-cph-paper font-medium py-2 px-6 rounded-lg transition-colors duration-200 flex items-center gap-2"
+            className="px-6"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -157,7 +158,7 @@ export default function ModalForm({ date, closeModal }: ModalFormProps) {
               />
             </svg>
             <span>Block Event</span>
-          </button>
+          </Button>
         )}
         <SubmitButton />
       </div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,5 +19,8 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "tailwind-merge": "^3.6.0"
   }
 }

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,34 +1,59 @@
 import { ButtonHTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
 
-export type ButtonVariant = "primary" | "destructive" | "outline";
+export type ButtonVariant =
+  | "primary"
+  | "destructive"
+  | "success"
+  | "outline"
+  | "ghost"
+  | "link";
+
+export type ButtonSize = "default" | "sm" | "icon" | "none";
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: ButtonVariant;
+  size?: ButtonSize;
 };
 
 // Shared base for every button: layout, shape, motion, and a pointer cursor
 // (Tailwind v4's Preflight no longer sets cursor: pointer on <button>).
 const base =
-  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg px-4 py-2 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg font-medium transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50";
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary: "bg-cph-ochre text-cph-navy hover:bg-amber-300",
-  destructive: "bg-cph-rust text-cph-paper hover:bg-cph-rust/80",
-  outline:
-    "border border-cph-sky/30 text-cph-paper hover:border-cph-sky/60 hover:bg-white/5",
+  destructive: "bg-cph-rust text-cph-paper hover:bg-cph-rust/85",
+  success: "bg-cph-teal text-cph-paper hover:bg-cph-teal/85",
+  outline: "border border-cph-sky/30 text-cph-paper hover:bg-white/5",
+  ghost: "text-cph-paper hover:bg-white/10",
+  link: "text-cph-sky hover:text-cph-paper",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  default: "px-4 py-2",
+  sm: "px-4 py-2 text-sm",
+  icon: "p-2",
+  none: "",
 };
 
 export default function Button({
   variant = "primary",
+  size = "default",
   className,
   children,
   ...props
 }: ButtonProps) {
-  // twMerge lets callers override any base/variant class by passing their own.
+  // twMerge lets callers override any base/variant/size class by passing their
+  // own (e.g. `className="w-full"` or a one-off color).
   return (
     <button
-      className={twMerge(base, variantClasses[variant], className)}
+      className={twMerge(
+        base,
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
       {...props}
     >
       {children}

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,17 +1,34 @@
 import { ButtonHTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
+
+export type ButtonVariant = "primary" | "destructive" | "outline";
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  children: React.ReactNode;
+  variant?: ButtonVariant;
+};
+
+// Shared base for every button: layout, shape, motion, and a pointer cursor
+// (Tailwind v4's Preflight no longer sets cursor: pointer on <button>).
+const base =
+  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg px-4 py-2 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50";
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-cph-ochre text-cph-navy hover:bg-amber-300",
+  destructive: "bg-cph-rust text-cph-paper hover:bg-cph-rust/80",
+  outline:
+    "border border-cph-sky/30 text-cph-paper hover:border-cph-sky/60 hover:bg-white/5",
 };
 
 export default function Button({
+  variant = "primary",
+  className,
   children,
-  className = "",
   ...props
 }: ButtonProps) {
+  // twMerge lets callers override any base/variant class by passing their own.
   return (
     <button
-      className={`bg-cph-ochre text-cph-navy px-4 py-2 rounded-lg hover:bg-amber-300 transition-colors ${className}`}
+      className={twMerge(base, variantClasses[variant], className)}
       {...props}
     >
       {children}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,4 @@
 export { default as Button } from "./Button";
-export type { ButtonVariant } from "./Button";
+export type { ButtonVariant, ButtonSize } from "./Button";
 export { default as TextInput } from "./TextInput";
 export { default as DateInput } from "./DateInput";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from "./Button";
+export type { ButtonVariant } from "./Button";
 export { default as TextInput } from "./TextInput";
 export { default as DateInput } from "./DateInput";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       react-dom:
         specifier: '>=19'
         version: 19.2.7(react@19.2.7)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
     devDependencies:
       '@repo/config':
         specifier: workspace:*
@@ -2550,6 +2553,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
@@ -5293,6 +5299,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.1: {}
 


### PR DESCRIPTION
## Description

Turns the shared `@repo/ui` `Button` into a proper, reusable styled component so buttons look consistent everywhere and can be extended per-use. Also fixes the missing hover pointer cursor.

## Why the cursor was missing

Tailwind CSS v4's Preflight **removed** the `button { cursor: pointer }` rule that v3 shipped, so raw `<button>` elements fall back to the native `cursor: default` (arrow). The "Boka" and "Block Event" buttons were plain `<button>`s, so they no longer changed cursor on hover.

## Changes

- **`packages/ui/src/Button.tsx`**
  - `cursor-pointer` baked into the base styles (and `disabled:cursor-not-allowed`).
  - `variant` prop: `primary` (ochre), `destructive` (rust), `outline` (sky border) — the three button styles the app actually uses.
  - Class overrides via `tailwind-merge`, so callers can append or override any base/variant class safely (e.g. `className="px-6"` wins over the base `px-4`).
  - Backward compatible — existing `<Button>` usage in `AddAdminForm` keeps working (defaults to `primary`).
- **`ModalForm.tsx`** — migrated the Boka and Block Event buttons to `<Button>`, restoring the pointer cursor.
- Added `tailwind-merge` to `@repo/ui`.

## Testing

- `pnpm --filter @repo/ui typecheck` ✅
- `pnpm --filter web` typecheck + lint ✅
- `pnpm --filter web build` ✅